### PR TITLE
atom:修正IFAA在编译时的报错

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -97,10 +97,7 @@ PRODUCT_PACKAGES += \
 
 # IFAA manager
 PRODUCT_PACKAGES += \
-    org.ifaa.android.manager
-
-PRODUCT_BOOT_JARS += \
-    org.ifaa.android.manager
+   include device/xiaomi/extras/ifaa.mk
 
 # Ramdisk
 PRODUCT_PACKAGES += \


### PR DESCRIPTION
* Fixes error: frameworks/base/boot/Android.bp:44:1: "platform-bootclasspath" depends on undefined module "org.ifaa.android.manager"
  Module "platform-bootclasspath" is defined in namespace "." which can read these 1 namespaces: ["."]
  Module "org.ifaa.android.manager" can be found in these namespaces

Signed-off-by: ZhcnPanda <2623493447@qq.com>